### PR TITLE
Bugfix: Wrong include in max31328 Alarm2 example

### DIFF
--- a/examples/MAX31328/Alarm2/Alarm2.ino
+++ b/examples/MAX31328/Alarm2/Alarm2.ino
@@ -1,4 +1,4 @@
-#include <MaxEssentialToolkit.h>
+#include <AnalogRTCLibrary.h>
 
 MAX31328 rtc(&Wire, MAX3128_I2C_ADDRESS);
 


### PR DESCRIPTION
The example for Alarm2 of MAX31328 had a faulty include and when tested failed. The fix is to include AnalogRTCLibrary.h instead.